### PR TITLE
remove override

### DIFF
--- a/server/src/ycm.ts
+++ b/server/src/ycm.ts
@@ -70,7 +70,6 @@ export default class Ycm{
         this.hmacSecret = hmac
         options.hmac_secret = this.hmacSecret.toString('base64')
         options.global_ycm_extra_conf = this.settings.ycmd.global_extra_config
-        options.confirm_extra_conf = true
         options.extra_conf_globlist = []
         options.rustSrcPath = ''
         const optionsFile = path.resolve(os.tmpdir(), `VSCodeYcmOptions-${Date.now()}`)


### PR DESCRIPTION
- confirmation dialog doesn't work
- no custom per project ycm_extra_conf can't be loaded because of it

This is a quickfix before someone adds the dialog.

Still doesn't work if `confirm_extra_conf` is `1` in the `default_settings.json`.
