### PR TITLE
use goTo instead of goToDefinition

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -91,7 +91,7 @@ connection.onHover(async (event): Promise<Hover> => {
 connection.onDefinition(async (event) => {
     const ycm = await getYcm()
     try {
-        return await ycm.goToDefinition(event.textDocument.uri, event.position, documents)
+        return await ycm.goTo(event.textDocument.uri, event.position, documents)
     } catch (err) {
         logger(`onDefinition error`, err)
     }

--- a/server/src/ycm.ts
+++ b/server/src/ycm.ts
@@ -222,9 +222,9 @@ export default class Ycm {
         return mapYcmTypeToHover(type, documents.get(documentUri).languageId)
     }
 
-    public async goToDefinition(documentUri: string, position: Position, documents: TextDocuments) {
-        const definition = await this.runCompleterCommand(documentUri, position, documents, 'GoToDefinition')
-        logger('goToDefinition', JSON.stringify(definition))
+    public async goTo(documentUri: string, position: Position, documents: TextDocuments) {
+        const definition = await this.runCompleterCommand(documentUri, position, documents, 'GoTo')
+        logger('goTo', JSON.stringify(definition))
         return mapYcmLocationToLocation(definition as YcmLocation)
     }
 


### PR DESCRIPTION
Since vscode has only one kind of 'goto' command, it makes sense
to use the one that does the "most sensible" thing.

From https://github.com/Valloric/YouCompleteMe#goto-commands
This command tries to perform the "most sensible" GoTo operation it can.
Currently, this means that it tries to look up the symbol under the cursor
and jumps to its definition if possible; if the definition is not accessible
from the current translation unit, jumps to the symbol's declaration.
For C/C++/Objective-C, it first tries to look up the current line for a header
and jump to it.