### PR TITLE
require vscode engine version ^1.8.0

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/richard1122/vscode-youcompleteme"
   },
   "engines": {
-    "vscode": "^1.6.0"
+    "vscode": "^1.8.0"
   },
   "categories": [
     "Languages"


### PR DESCRIPTION
I was getting `client.d.ts(4,139): error TS2305: Module ''vscode'' has no exported member 'ProviderResult'` with the current value of ^1.6.0

^1.8.0 was the first version that compiled successfully.