### PR TITLE
show diagnostic for errors in header file

### DIFF
--- a/server/src/ycm.ts
+++ b/server/src/ycm.ts
@@ -278,7 +278,7 @@ export default class Ycm {
                 reported_issues.unshift(header_issues[0]);
             }
 
-            return utils_1.mapYcmDiagnosticToLanguageServerDiagnostic(reported_issues).filter(it => !!it.range);
+            return mapYcmDiagnosticToLanguageServerDiagnostic(reported_issues).filter(it => !!it.range);
         } catch (err) {
             return []
         }

--- a/server/src/ycm.ts
+++ b/server/src/ycm.ts
@@ -289,7 +289,7 @@ export default class Ycm {
             }
             logger(`readyToParse->reported_issues`, JSON.stringify(reported_issues))
 
-            return mapYcmDiagnosticToLanguageServerDiagnostic(reported_issues).filter(it => !!it.range);
+            return mapYcmDiagnosticToLanguageServerDiagnostic(reported_issues).filter(it => !!it.range)
         } catch (err) {
             return []
         }


### PR DESCRIPTION
If there are issues we come across in files other than the
one we're looking at, it's probably from an included header.
Since they may be the root cause of errors in the file
we're looking at, instead of filtering them all out, let's
just pick the first one to display and hard-code it to
show up on the first line, since the language
server diagnostic interface doesn't appear to be able to
report errors in different files.