### PR TITLE
Enhance the logic for showing the hover popup

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -88,8 +88,10 @@ connection.onHover(async (event): Promise<Hover> => {
         try {
             // libclang does not return anything for getDoc if there is no doxygen
             // documentation for an identifier, so we next try to see if we
-            // can get a member function signature from a completion (since getType
-            // returns an unhelpful "<bound member function>" for them).
+            // can get a member function signature from a completion (since getType()
+            // returns an unhelpful "<bound member function>" for them).  This isn't
+            // ideal since we won't be able to tell exactly which overload is being
+            // called.
             let matchingCompletion = await ycm.getExactMatchingCompletion(event.textDocument.uri, event.position, documents)
             if ( matchingCompletion ) {
                 return {
@@ -100,8 +102,10 @@ connection.onHover(async (event): Promise<Hover> => {
                 } as Hover
             }
             else {
-                // We're either on a non-member function or a variable
-                return await ycm.getType(event.textDocument.uri, event.position, documents, workspaceConfiguration.ycmd.use_imprecise_get_type)
+                // We're either on a non-member function or a variable, so just use getType().
+                // We called getDoc above with workspaceConfiguration.ycmd.use_imprecise_get_type
+                // so, no reason to have ycmd parse the file again.
+                return await ycm.getType(event.textDocument.uri, event.position, documents, true)
             }
         }
         catch (err) {

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -82,9 +82,31 @@ connection.onNotification<YcmFixIt, string>(new NotificationType<YcmFixIt, strin
 connection.onHover(async (event): Promise<Hover> => {
     const ycm = await getYcm()
     try {
-        return await ycm.getType(event.textDocument.uri, event.position, documents, workspaceConfiguration.ycmd.use_imprecise_get_type)
-    } catch (err) {
-        logger(`onHover error`, err)
+        return await ycm.getDocHover(event.textDocument.uri, event.position, documents, workspaceConfiguration.ycmd.use_imprecise_get_type)
+    }
+    catch (getDocErr) {
+        try {
+            // libclang does not return anything for getDoc if there is no doxygen
+            // documentation for an identifier, so we next try to see if we
+            // can get a member function signature from a completion (since getType
+            // returns an unhelpful "<bound member function>" for them).
+            let matchingCompletion = await ycm.getExactMatchingCompletion(event.textDocument.uri, event.position, documents)
+            if ( matchingCompletion ) {
+                return {
+                    contents: {
+                        language: documents.get(event.textDocument.uri).languageId,
+                        value: matchingCompletion.detail
+                    }
+                } as Hover
+            }
+            else {
+                // We're either on a non-member function or a variable
+                return await ycm.getType(event.textDocument.uri, event.position, documents, workspaceConfiguration.ycmd.use_imprecise_get_type)
+            }
+        }
+        catch (err) {
+            logger(`onHover error`, err)
+        }
     }
 })
 

--- a/server/src/utils.ts
+++ b/server/src/utils.ts
@@ -116,6 +116,8 @@ export function mapYcmDiagnosticToLanguageServerDiagnostic(items: YcmDiagnosticI
 export function mapYcmTypeToHover(res: YcmGetTypeResponse, language: string): Hover | null {
     if (res.message === 'Unknown type') return null
     if (res.message === 'Internal error: cursor not valid') return null
+    // TODO: we should retry if we get no translation unit, since it means
+    //       that libclang is still processing the file.
     if (res.message === 'Internal error: no translation unit') return null
     logger('mapYcmTypeToHover', `language: ${language}`)
     return {

--- a/server/src/utils.ts
+++ b/server/src/utils.ts
@@ -17,7 +17,7 @@ export function mapYcmCompletionsToLanguageServerCompletions(CompletionItems: Yc
             label: it.menu_text || it.insertion_text,
             detail: it.detailed_info,
             insertText: it.insertion_text,
-            documentation: it.detailed_info,
+            // documentation: it.detailed_info,
             sortText: _.padStart(index.toString(), len, '0')
         } as CompletionItem
         switch (it.kind || it.extra_menu_info) {
@@ -125,16 +125,16 @@ export function mapYcmTypeToHover(res: YcmGetTypeResponse, language: string): Ho
             language: language,
             // clang gives us 'declared_type => resolved_type';
             // we show just the more user-friendly declared type
-            value: res.message.split(" => ")[0]
+            value: res.message.split(' => ')[0]
         } as MarkedString
     } as Hover
 }
 
 export function mapYcmDocToHover(res: YcmCompletionItem, language: string) {
     logger('mapYcmDocToHover', `language: ${language}`)
-    const full_str = res.detailed_info.toString();
+    const full_str = res.detailed_info.toString()
     // signature is the first line
-    const signature = full_str.split("\n")[0]
+    const signature = full_str.split('\n')[0]
     // brief documentation follows, up until the 'Type:' line
     const brief_doc = full_str.substring(signature.length + 1,
         full_str.search('\nType:'))

--- a/server/src/ycm.ts
+++ b/server/src/ycm.ts
@@ -234,7 +234,7 @@ export default class Ycm {
             let currDocString = currDoc.getText()
             let currOffset = currDoc.offsetAt(position)
             let nameStart = currOffset
-            // search for the current identifier
+            // get the current identifier
             while (currDocString[currOffset].match(/[A-Z|a-z|0-9|_]/))
                 currOffset++
             while (currDocString[nameStart].match(/[A-Z|a-z|0-9|_]/))
@@ -252,9 +252,9 @@ export default class Ycm {
     }
 
     public async getDocHover(documentUri, position, documents, imprecise = false) {
-            const completion = await this.runCompleterCommand(documentUri, position, documents, imprecise ? 'GetDocImprecise' : 'GetDoc')
-            logger('getDocHover', JSON.stringify(completion))
-            return mapYcmDocToHover(completion, documents.get(documentUri).languageId)
+            const doc = await this.runCompleterCommand(documentUri, position, documents, imprecise ? 'GetDocImprecise' : 'GetDoc')
+            logger('getDocHover', JSON.stringify(doc))
+            return mapYcmDocToHover(doc, documents.get(documentUri).languageId)
     }
 
     public async getDoc(documentUri: string, position: Position, documents: TextDocuments) {

--- a/server/src/ycm.ts
+++ b/server/src/ycm.ts
@@ -15,7 +15,8 @@ import {
     logger,
     crossPlatformUri,
     mapYcmTypeToHover,
-    mapYcmLocationToLocation
+    mapYcmLocationToLocation,
+    mapYcmDocToHover
 } from './utils'
 
 import {
@@ -226,6 +227,34 @@ export default class Ycm {
         const definition = await this.runCompleterCommand(documentUri, position, documents, 'GoTo')
         logger('goTo', JSON.stringify(definition))
         return mapYcmLocationToLocation(definition as YcmLocation)
+    }
+
+    public async getExactMatchingCompletion(documentUri, position, documents) {
+            let currDoc = documents.get(documentUri)
+            let currDocString = currDoc.getText()
+            let currOffset = currDoc.offsetAt(position)
+            let nameStart = currOffset
+            // search for the current identifier
+            while (currDocString[currOffset].match(/[A-Z|a-z|0-9|_]/))
+                currOffset++
+            while (currDocString[nameStart].match(/[A-Z|a-z|0-9|_]/))
+                nameStart--
+            let identifierName = currDocString.slice(nameStart + 1, currOffset)
+            // find exact match for current identifier
+            let completionArray = await this.completion(documentUri, currDoc.positionAt(currOffset - 1), documents)
+            return completionArray.find(function (elem) {
+                // if a file has compilation problems, ycmd will fall back to ID-based
+                // completions, which have only `extra_menu_info: "[ID]"` as additional
+                // info, so we filter those useless ones out by looking to see if they
+                // have what we really want: the `detail` info.
+                return elem.insertText === identifierName  && !!elem.detail
+            })
+    }
+
+    public async getDocHover(documentUri, position, documents, imprecise = false) {
+            const completion = await this.runCompleterCommand(documentUri, position, documents, imprecise ? 'GetDocImprecise' : 'GetDoc')
+            logger('getDocHover', JSON.stringify(completion))
+            return mapYcmDocToHover(completion, documents.get(documentUri).languageId)
     }
 
     public async getDoc(documentUri: string, position: Position, documents: TextDocuments) {


### PR DESCRIPTION
The current getType does not return useful information for member functions.  getDoc returns the most useful info, for things that have documentation, but nothing for things that do not.  Next we try to find an exact completion for the identifier and use its signature.  getType() is appropriate for the remaining cases.

This is kind of a followup to the conversation at https://github.com/Valloric/ycmd/pull/598
If you disagree with any of the design decisions, feel free to rework or let me know what you'd like changed.  There will be a separate pull request to correct the documentation of what we show in the suggested completion.