### PR TITLE
Enhance the logic for showing the hover popup

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -87,9 +87,10 @@
   "scripts": {
     "vscode:prepublish": "tsc -p ./",
     "compile": "tsc -watch -p ./",
-    "postinstall": "node ./node_modules/vscode/bin/install",
     "lint": "tslint -c ../tslint.json './src/*' && tslint -c ../tslint.json '../server/src/*'",
-    "test": "node out/test/index"
+    "test": "node out/test/index",
+    "update-vscode": "node ./node_modules/vscode/bin/install",
+    "postinstall": "node ./node_modules/vscode/bin/install"
   },
   "devDependencies": {
     "@types/mocha": "^2.2.32",

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -2,15 +2,14 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
-
 'use strict'
+/// <reference path="../typings/ycm.d.ts" />
 import {MapYcmFixItToVSCodeEdit} from './utils'
 
 import * as path from 'path'
 
 import { workspace, Disposable, ExtensionContext, window, commands } from 'vscode'
 import { LanguageClient, LanguageClientOptions, SettingMonitor, ServerOptions, TransportKind } from 'vscode-languageclient'
-import { YcmFixIt } from '../typings/ycm'
 
 let client: LanguageClient
 let disposable: Disposable

--- a/client/src/utils.ts
+++ b/client/src/utils.ts
@@ -1,5 +1,5 @@
+/// <reference path="../typings/ycm.d.ts" />
 import { WorkspaceEdit, Uri, TextEdit, Position, Range} from 'vscode'
-import { YcmFixIt, YcmRange, YcmLocation, YcmChunk } from '../typings/ycm'
 
 export function MapYcmFixItToVSCodeEdit(fixIt: YcmFixIt): WorkspaceEdit {
     const chunks = YcmFixItToChunkFiles(fixIt)

--- a/client/typings/ycm.d.ts
+++ b/client/typings/ycm.d.ts
@@ -1,4 +1,4 @@
-export type YcmCompletionItem = {
+type YcmCompletionItem = {
     menu_text: string
     insertion_text: string
     detailed_info: string
@@ -7,22 +7,22 @@ export type YcmCompletionItem = {
     extra_data?: YcmCompletionExtraData
 }
 
-export type YcmCompletionExtraData = {
+type YcmCompletionExtraData = {
     doc_string: string
 }
 
-export type YcmLocation = {
+type YcmLocation = {
     filepath: string
     column_num: number
     line_num: number
 }
 
-export type YcmRange = {
+type YcmRange = {
     start: YcmLocation
     end: YcmLocation
 }
 
-export type YcmDiagnosticItem = {
+type YcmDiagnosticItem = {
     kind: 'ERROR' | 'WARNING'
     text: string
     ranges: YcmRange[]
@@ -31,17 +31,17 @@ export type YcmDiagnosticItem = {
     fixit_available: boolean
 }
 
-export type YcmChunk = {
+type YcmChunk = {
     range: YcmRange
     replacement_text: string
 }
 
-export type YcmFixIt = {
+type YcmFixIt = {
     chunks: YcmChunk[]
     text: string
     location: YcmLocation
 }
 
-export type YcmGetTypeResponse = {
+type YcmGetTypeResponse = {
     message: string
 }

--- a/client/typings/ycm.ts
+++ b/client/typings/ycm.ts
@@ -4,6 +4,11 @@ export type YcmCompletionItem = {
     detailed_info: string
     extra_menu_info: string
     kind: string
+    extra_data?: YcmCompletionExtraData
+}
+
+export type YcmCompletionExtraData = {
+    doc_string: string
 }
 
 export type YcmLocation = {

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 'use strict'
-
+/// <reference path="../../client/typings/ycm.d.ts" />
 import {
     IPCMessageReader, IPCMessageWriter,
     createConnection, IConnection, TextDocumentSyncKind,
@@ -15,7 +15,6 @@ import {
 import Ycm, {Settings} from './ycm'
 import * as _ from 'lodash'
 import {logger, loggerInit, crossPlatformUri} from './utils'
-import * as YcmTypes from '../../client/typings/ycm'
 
 process.on('uncaughtException', err => {
     logger('!!!uncaughtException!!!', err)
@@ -75,7 +74,7 @@ connection.onCodeAction(async (param) => {
     return []
 })
 
-connection.onNotification<YcmTypes.YcmFixIt, string>(new NotificationType<YcmTypes.YcmFixIt, string>('FixIt'), async (args) => {
+connection.onNotification<YcmFixIt, string>(new NotificationType<YcmFixIt, string>('FixIt'), async (args) => {
     logger('On FixIt', JSON.stringify(args))
 })
 

--- a/server/src/utils.ts
+++ b/server/src/utils.ts
@@ -1,3 +1,4 @@
+/// <reference path="../../client/typings/ycm.d.ts" />
 import {
     IPCMessageReader, IPCMessageWriter,
     createConnection, IConnection, TextDocumentSyncKind,
@@ -9,9 +10,9 @@ import * as _ from 'lodash'
 import * as Buffer from 'buffer'
 import Uri from 'vscode-uri'
 const iconv = require('iconv-lite')
-import * as YcmTypes from '../../client/typings/ycm'
 
-export function mapYcmCompletionsToLanguageServerCompletions(CompletionItems: YcmTypes.YcmCompletionItem[] = []): CompletionItem[] {
+
+export function mapYcmCompletionsToLanguageServerCompletions(CompletionItems: YcmCompletionItem[] = []): CompletionItem[] {
     const len = CompletionItems.length.toString().length
     return _.map(CompletionItems, (it, index) => {
         // put the signature (detail_info) on the first line;
@@ -71,7 +72,7 @@ export function mapYcmCompletionsToLanguageServerCompletions(CompletionItems: Yc
     })
 }
 
-export function mapYcmDiagnosticToLanguageServerDiagnostic(items: YcmTypes.YcmDiagnosticItem[]): Diagnostic[] {
+export function mapYcmDiagnosticToLanguageServerDiagnostic(items: YcmDiagnosticItem[]): Diagnostic[] {
     return _.map(items, (it, index) => {
         const item = {
             range: null,
@@ -122,7 +123,7 @@ export function mapYcmDiagnosticToLanguageServerDiagnostic(items: YcmTypes.YcmDi
     })
 }
 
-export function mapYcmTypeToHover(res: YcmTypes.YcmGetTypeResponse, language: string): Hover | null {
+export function mapYcmTypeToHover(res: YcmGetTypeResponse, language: string): Hover | null {
     if (res.message === 'Unknown type') return null
     if (res.message === 'Internal error: cursor not valid') return null
     // TODO: we should retry if we get no translation unit, since it means
@@ -139,7 +140,7 @@ export function mapYcmTypeToHover(res: YcmTypes.YcmGetTypeResponse, language: st
     } as Hover
 }
 
-export function mapYcmLocationToLocation(location: YcmTypes.YcmLocation): Location {
+export function mapYcmLocationToLocation(location: YcmLocation): Location {
     return {
         uri: Uri.file(location.filepath).toString(),
         range: {
@@ -155,7 +156,7 @@ export function mapYcmLocationToLocation(location: YcmTypes.YcmLocation): Locati
     } as Location
 }
 
-export function mapYcmDocToHover(res: YcmTypes.YcmCompletionItem, language: string) {
+export function mapYcmDocToHover(res: YcmCompletionItem, language: string) {
     logger('mapYcmDocToHover', `language: ${language}`)
     const full_str = res.detailed_info.toString()
     let signature

--- a/server/src/ycm.ts
+++ b/server/src/ycm.ts
@@ -16,7 +16,8 @@ import {
     logger,
     crossPlatformUri,
     mapYcmTypeToHover,
-    mapYcmLocationToLocation
+    mapYcmLocationToLocation,
+    mapYcmDocToHover
 } from './utils'
 
 import {
@@ -227,6 +228,35 @@ export default class Ycm {
         const definition = await this.runCompleterCommand(documentUri, position, documents, 'GoTo')
         logger('goTo', JSON.stringify(definition))
         return mapYcmLocationToLocation(definition as YcmTypes.YcmLocation)
+    }
+
+    public async getExactMatchingCompletion(documentUri, position, documents) {
+            let currDoc = documents.get(documentUri)
+            let currDocString = currDoc.getText()
+            let currOffset = currDoc.offsetAt(position)
+            let nameStart = currOffset
+            // get the current identifier
+            while (currDocString[currOffset].match(/[A-Z|a-z|0-9|_]/))
+                currOffset++
+            while (currDocString[nameStart].match(/[A-Z|a-z|0-9|_]/))
+                nameStart--
+            let identifierName = currDocString.slice(nameStart + 1, currOffset)
+            // find exact match for current identifier
+            let completionArray = await this.completion(documentUri, currDoc.positionAt(currOffset - 1), documents)
+            return completionArray.find(function (elem) {
+                // if a file has compilation problems, ycmd will fall back to ID-based
+                // completions, which have only `extra_menu_info: "[ID]"` as additional
+                // info, so we filter those useless ones out by looking to see if they
+                // have what we really want: the signature at the top of the
+                // `documentation` info.
+                return elem.insertText === identifierName && !!elem.documentation
+            })
+    }
+
+    public async getDocHover(documentUri, position, documents, imprecise = false) {
+            const doc = await this.runCompleterCommand(documentUri, position, documents, imprecise ? 'GetDocImprecise' : 'GetDoc')
+            logger('getDocHover', JSON.stringify(doc))
+            return mapYcmDocToHover(doc, documents.get(documentUri).languageId)
     }
 
     public async getDoc(documentUri: string, position: Position, documents: TextDocuments) {

--- a/server/src/ycm.ts
+++ b/server/src/ycm.ts
@@ -1,3 +1,4 @@
+/// <reference path="../../client/typings/ycm.d.ts" />
 import * as net from 'net'
 import * as crypto from 'crypto'
 import * as childProcess from 'child_process'
@@ -7,7 +8,7 @@ import * as os from 'os'
 import * as _ from 'lodash'
 import * as url from 'url'
 import * as qs from 'querystring'
-import * as YcmTypes from '../../client/typings/ycm'
+
 
 import {
     mapYcmCompletionsToLanguageServerCompletions,
@@ -212,14 +213,14 @@ export default class Ycm {
     public async completion(documentUri: string, position: Position, documents: TextDocuments): Promise<CompletionItem[]> {
         const request = this.buildRequest(documentUri, position, documents)
         const response = await request.request('completions')
-        const completions = response['completions'] as YcmTypes.YcmCompletionItem[]
+        const completions = response['completions'] as YcmCompletionItem[]
         const res = mapYcmCompletionsToLanguageServerCompletions(completions)
         logger(`completion`, `ycm responsed ${res.length} items`)
         return res
     }
 
     public async getType(documentUri: string, position: Position, documents: TextDocuments, imprecise: boolean = false) {
-        const type = await this.runCompleterCommand(documentUri, position, documents, imprecise ? 'GetTypeImprecise' : 'GetType') as YcmTypes.YcmGetTypeResponse
+        const type = await this.runCompleterCommand(documentUri, position, documents, imprecise ? 'GetTypeImprecise' : 'GetType') as YcmGetTypeResponse
         logger('getType', JSON.stringify(type))
         return mapYcmTypeToHover(type, documents.get(documentUri).languageId)
     }
@@ -227,7 +228,7 @@ export default class Ycm {
     public async goTo(documentUri: string, position: Position, documents: TextDocuments) {
         const definition = await this.runCompleterCommand(documentUri, position, documents, 'GoTo')
         logger('goTo', JSON.stringify(definition))
-        return mapYcmLocationToLocation(definition as YcmTypes.YcmLocation)
+        return mapYcmLocationToLocation(definition as YcmLocation)
     }
 
     public async getExactMatchingCompletion(documentUri, position, documents) {
@@ -274,7 +275,7 @@ export default class Ycm {
             const response = await this.eventNotification(documentUri, null, documents, 'FileReadyToParse')
             if (!_.isArray(response)) return []
             logger(`readyToParse`, `ycm responsed ${response.length} items`)
-            const issues = response as YcmTypes.YcmDiagnosticItem[]
+            const issues = response as YcmDiagnosticItem[]
             const uri = crossPlatformUri(documentUri)
 
             const [reported_issues, header_issues] = _.partition(issues, it => it.location.filepath === uri)
@@ -328,7 +329,7 @@ export default class Ycm {
 
     public async fixIt(documentUri: string, position: Position, documents: TextDocuments) {
         const response = await this.runCompleterCommand(documentUri, position, documents, 'FixIt')
-        const fixits = response.fixits as YcmTypes.YcmFixIt[]
+        const fixits = response.fixits as YcmFixIt[]
         const uri = crossPlatformUri(documentUri)
         fixits.forEach(it => {
             if (it.text.indexOf(uri) !== -1)

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -4,6 +4,7 @@
 		"module": "commonjs",
 		"sourceMap": true,
 		"outDir": "../client/server",
+		"sourceRoot": "./src",
 		"lib": [
             "es2016"
         ]


### PR DESCRIPTION
The current getType call does not return useful information for
member functions.  getDoc returns the most useful info, for
things that have documentation, but nothing for things that
do not.  Next we try to find an exact completion for the
identifier and use its signature.  getType is appropriate
for the remaining cases.

This also adds the available documentation to the completion help.