### PR TITLE
change activation events to be for languages c, cpp, and objective-c only

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -16,7 +16,9 @@
     "Languages"
   ],
   "activationEvents": [
-    "*"
+    "onLanguage:cpp",
+    "onLanguage:c",
+    "onLanguage:objective-c"
   ],
   "main": "./out/src/extension",
   "contributes": {


### PR DESCRIPTION
for people with ycmd.path set only in a workspace settings rather
than user settings, this change prevents the extension from complaining about
not being able to find ycmd when using vscode on an ad-hoc basis,
e.g. as the editor for git commit messages.  Also, it seems like the right
thing to do in general.