### PR TITLE
add fallback to resolve ycmd path

### DIFF
--- a/server/src/ycm.ts
+++ b/server/src/ycm.ts
@@ -59,8 +59,14 @@ export default class Ycm {
     private readDefaultOptions() {
         return new Promise<any>((resolve, reject) => {
             fs.readFile(path.resolve(this.settings.ycmd.path, 'ycmd', 'default_settings.json'), {encoding: 'utf8'}, (err, data) => {
-                if (err) reject(err)
-                else resolve(JSON.parse(data))
+                if (err) {
+                    fs.readFile(this.settings.ycmd.path, {encoding:'utf8'}, (err,data) =>{
+                        if (err) reject(err)
+                        else resolve(JSON.parse(data))
+                    })
+                }else{
+                    resolve(JSON.parse(data))
+                }
             })
         })
     }

--- a/server/src/ycm.ts
+++ b/server/src/ycm.ts
@@ -60,11 +60,11 @@ export default class Ycm {
         return new Promise<any>((resolve, reject) => {
             fs.readFile(path.resolve(this.settings.ycmd.path, 'ycmd', 'default_settings.json'), {encoding: 'utf8'}, (err, data) => {
                 if (err) {
-                    fs.readFile(this.settings.ycmd.path, {encoding:'utf8'}, (err,data) =>{
+                    fs.readFile(this.settings.ycmd.path, {encoding: 'utf8'}, (err, data) => {
                         if (err) reject(err)
                         else resolve(JSON.parse(data))
                     })
-                }else{
+                } else {
                     resolve(JSON.parse(data))
                 }
             })


### PR DESCRIPTION
My system doesn't find "default_settings.json" because for some reason it is named "default settings.json".  I think it might be a good alternative to use the user supplied ycmd path explicitly if the first path fails.

(Note I did not test this I am just getting started with vs code and not sure how to build extensions)...

